### PR TITLE
Revert "tecff-broken-wlan-workaround: add fix for mt7915 bug"

### DIFF
--- a/tecff-broken-wlan-workaround/files/lib/gluon/broken-wlan-workaround/broken-wlan-workaround.sh
+++ b/tecff-broken-wlan-workaround/files/lib/gluon/broken-wlan-workaround/broken-wlan-workaround.sh
@@ -148,17 +148,6 @@ if [ "$GWCONNECTION" -eq 0 ]; then
 	fi
 fi
 
-if ! cat /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval > /dev/null; then
-	# https://github.com/freifunk-gluon/gluon/issues/3154#issuecomment-2125452973
-    logger -p 0 -t "$SCRIPTNAME" "wifi seems crashed; reloading driver"; 
-	# delete old hostapd files, as they are not needed anymore
-	# and mangle with the ffac-ssid-changer
-	rmmod mt7915e && rm /var/run/hostapd-*.conf* && modprobe mt7915e
-	# directly restart wifi
-	WLANRESTART=1
-	touch $RESTARTFILE
-fi
-
 if [ ! -f "$RESTARTFILE" ] && [ "$WLANRESTART" -eq 1 ]; then
 	# delaying wlan restart until the next script run
 	touch $RESTARTFILE


### PR DESCRIPTION
This reverts commit 7df1c79a886472d61ecbdb828e81078c58307117.

This should not be part of the general package, as the path `/sys/kernel/debug/ieee80211/phy*/mt76` does not always exist and therefore fails for other reasons