### PR TITLE
add error related reboot and fix ffac-ssid-changer expectation of hostapd files

### DIFF
--- a/ffac-mt7915-hotfix/files/lib/gluon/mt7915/hotfix.sh
+++ b/ffac-mt7915-hotfix/files/lib/gluon/mt7915/hotfix.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
-logger -t "ffac-mt7915-hotfix" -p debug "reloading wifi firmware now"
+logger -t "ffac-mt7915-hotfix" -p err "reloading wifi firmware now"
 rmmod mt7915e
+# fix for ffac-ssid-changer to remove old hostapd config files
+rm /var/run/hostapd-*.conf*
 modprobe mt7915e
 wifi

--- a/ffac-mt7915-hotfix/files/lib/gluon/mt7915/reboot-on-error.sh
+++ b/ffac-mt7915-hotfix/files/lib/gluon/mt7915/reboot-on-error.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+if ls /sys/kernel/debug/ieee80211/phy*/mt76 && ! cat /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval > /dev/null; then
+    logger -s -t "ffac-mt7915-hotfix" -p err "wifi firmware crashed, scheduled reboot in 5 seconds"
+    sleep 5
+    # Autoupdate?
+    upgrade_started='/tmp/autoupdate.lock'
+    if [ -f $upgrade_started ] ; then
+        logger -s -t "ffac-threetime-reboot" -p 5 "Autoupdate running! Aborting"
+        exit 2
+    fi
+    reboot
+fi

--- a/ffac-mt7915-hotfix/files/usr/lib/micron.d/mt7915-hotfix
+++ b/ffac-mt7915-hotfix/files/usr/lib/micron.d/mt7915-hotfix
@@ -1,2 +1,3 @@
 # run every day at 05:45 and 17:45
 45 5,17 * * * /lib/gluon/mt7915/hotfix.sh
+* * * * * /lib/gluon/mt7915/reboot-on-error.sh


### PR DESCRIPTION
This adds a reboot when the mt7915e driver is existing and fails.
This is tested every minute.

It also removes the old hostapd.conf files to not irritate the ffac-ssid-changer which iterates over these..