### PR TITLE
ffac-mt7915-reload: rename PKG_NAME to match folder name

### DIFF
--- a/ffac-mt7915-hotfix/Makefile
+++ b/ffac-mt7915-hotfix/Makefile
@@ -20,18 +20,4 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Freifunk Aachen <kontakt@freifunk-aachen.de>
 endef
 
-define Build/Prepare
-  mkdir -p $(PKG_BUILD_DIR)
-endef
-
-define Build/Configure
-endef
-
-define Build/Compile
-endef
-
-define Package/$(PKG_NAME)/install
-  $(CP) ./files/* $(1)/
-endef
-
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffac-mt7915-reload/Makefile
+++ b/ffac-mt7915-reload/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=ffac-mt7915-hotfix
+PKG_NAME:=ffac-mt7915-reload
 PKG_VERSION:=1
 PKG_RELEASE:=1
 
@@ -20,18 +20,4 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Freifunk Aachen <kontakt@freifunk-aachen.de>
 endef
 
-define Build/Prepare
-  mkdir -p $(PKG_BUILD_DIR)
-endef
-
-define Build/Configure
-endef
-
-define Build/Compile
-endef
-
-define Package/$(PKG_NAME)/install
-  $(CP) ./files/* $(1)/
-endef
-
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))


### PR DESCRIPTION
this fixes the error, that this package could not be installed.