### PR TITLE
ffac-mt7915-hotfix: fix target mediatek_mt7622

### DIFF
--- a/ffac-mt7915-hotfix/Makefile
+++ b/ffac-mt7915-hotfix/Makefile
@@ -16,7 +16,7 @@ define Package/$(PKG_NAME)
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=reboot device if mt7915e driver shows known failure symptom
-  DEPENDS:=@(TARGET_mediatek_filogic||TARGET_ramips_mt7621||TARGET_ramips_mt7622) kmod-mt7915e +gluon-core +micrond
+  DEPENDS:=@(TARGET_mediatek_filogic||TARGET_ramips_mt7621||TARGET_mediatek_mt7622) kmod-mt7915e +gluon-core +micrond
   MAINTAINER:=Freifunk Aachen <kontakt@freifunk-aachen.de>
 endef
 


### PR DESCRIPTION
ffac-mt7915-hotfix: fix target from rampis to mediatek