### PR TITLE
ffac-mt7915-backlog: initial version

### DIFF
--- a/ffac-mt7915-backlog/LICENSE
+++ b/ffac-mt7915-backlog/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Florian Maurer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ffac-mt7915-backlog/Makefile
+++ b/ffac-mt7915-backlog/Makefile
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2024 Felix Baumann, Florian Maurer (FFAC)
+# SPDX-License-Identifier: MIT
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffac-mt7915-hotfix
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+PKG_LICENSE:=MIT
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=reboot device if mt7915e driver shows known failure symptom
+  DEPENDS:=@(TARGET_mediatek_filogic||TARGET_ramips_mt7621||TARGET_mediatek_mt7622) kmod-mt7915e +gluon-core +micrond
+  MAINTAINER:=Freifunk Aachen <kontakt@freifunk-aachen.de>
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffac-mt7915-backlog/README.md
+++ b/ffac-mt7915-backlog/README.md
@@ -1,0 +1,32 @@
+ffac-mt7915-backlog
+=============
+
+This package restarts wifi if the mt7915-backlog has more than 50 packets in the queue on ramips-mt7621
+and mediatek-filogic. It's meant as a hotfix for the mcu timeout issue:
+https://github.com/freifunk-gluon/gluon/issues/3154
+
+Create a file `modules` with the following content in your `./gluon/site/`
+directory and add these lines: 
+
+```
+GLUON_SITE_FEEDS="community"
+PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
+PACKAGES_COMMUNITY_COMMIT=*/missing/*
+PACKAGES_COMMUNITY_BRANCH=master
+```
+
+Now you can add the package `ffac-mt7915-backlog` to your site.mk
+(`*/missing/*` has to be replaced by the github-commit-ID of the version you
+want to use, you have to pick it manually.)
+
+Further info on the issue this tries to prevent from happening:
+When the backlog queue fill up, the device does not respond over wlan reliably.
+Sometimes, the backlog is cleared after a few minutes,
+but in busy environments this takes far too long and gets the system into an unresponsive state.
+Pings are not responend, traffic is stalled.
+
+I experienced these issues on various Zyxel NWA 55 AXE as well as on an Acer Vero W6M in busy environments.
+This happens on 5GHz as well as on 2.4GHz ifaces, depending on where the higher load is.
+Other devices with mt7915 like COVR-X1860 and DAP-X1860 are not affected on openwrt-24.10
+
+Also see https://github.com/openwrt/mt76/issues/1009

--- a/ffac-mt7915-backlog/files/lib/gluon/mt7915/restart-wifi-if-backlog-filled.sh
+++ b/ffac-mt7915-backlog/files/lib/gluon/mt7915/restart-wifi-if-backlog-filled.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+for phy in /sys/kernel/debug/ieee80211/phy*; do
+    phy_name=$(basename "$phy")
+    backlog=$(iw phy "$phy_name" get txq | awk '/Backlog/ {print $2}')
+    
+    if [ "$backlog" -gt 50 ]; then
+        logger -s -t "ffac-mt7915-backlog" -p 5 "$phy_name: Backlog > 50 ($backlog) - restarting wifi"
+        wifi
+	wifi
+    elif [ "$backlog" -gt 0 ]; then
+        logger -s -t "ffac-mt7915-backlog" -p 5 "$phy_name: Backlog ($backlog)"
+    fi
+done
+

--- a/ffac-mt7915-backlog/files/usr/lib/micron.d/mt7915-backlog
+++ b/ffac-mt7915-backlog/files/usr/lib/micron.d/mt7915-backlog
@@ -1,0 +1,2 @@
+# run every second minute
+*/2 * * * * /lib/gluon/mt7915/restart-wifi-if-backlog-filled.sh


### PR DESCRIPTION
When the backlog queue fill up, the device does not respond over wlan reliably. Sometimes, the backlog is cleared after a few minutes, but in busy environments this takes far too long and gets the system into an unresponsive state. Pings are not responend, traffic is stalled.

I experienced these issues on various Zyxel NWA 55 AXE as well as on an Acer Vero W6M in busy environments.

See also: https://github.com/openwrt/mt76/issues/1009